### PR TITLE
Fixed name

### DIFF
--- a/_posts/2022-12-21-rieck22a.md
+++ b/_posts/2022-12-21-rieck22a.md
@@ -13,7 +13,7 @@ lastpage: xxiii
 page: i-xxiii
 order: 0
 cycles: false
-bibtex_author: Rieck, Bastian and Pascanu, Razvan and Du, Yuanqi and Stärk, Hannes
+bibtex_author: Rieck, Bastian and Pascanu, Razvan and Du, Yuanqi and St\"{a}rk, Hannes
   and Lim, Derek and Joshi, Chaitanya K. and Deac, Andreea and Duta, Iulia and Robinson,
   Joshua and Corso, Gabriele and Cotta, Leonardo and Zhu, Yanqiao and Huang, Kexin
   and Li, Michelle and Bourhim, Sofia and Igashov, Ilia

--- a/_posts/2022-12-21-rieck22a.md
+++ b/_posts/2022-12-21-rieck22a.md
@@ -13,7 +13,7 @@ lastpage: xxiii
 page: i-xxiii
 order: 0
 cycles: false
-bibtex_author: Rieck, Bastian and Pascanu, Razvan and Du, Yuanqi and St"{a}rk, Hannes
+bibtex_author: Rieck, Bastian and Pascanu, Razvan and Du, Yuanqi and Stärk, Hannes
   and Lim, Derek and Joshi, Chaitanya K. and Deac, Andreea and Duta, Iulia and Robinson,
   Joshua and Corso, Gabriele and Cotta, Leonardo and Zhu, Yanqiao and Huang, Kexin
   and Li, Michelle and Bourhim, Sofia and Igashov, Ilia
@@ -25,7 +25,7 @@ author:
 - given: Yuanqi
   family: Du
 - given: Hannes
-  family: St"ark
+  family: Stärk
 - given: Derek
   family: Lim
 - given: Chaitanya K.


### PR DESCRIPTION
It's unclear to me whether one can use UTF-8 here, but I think this is what worked in other cases. Unrelated: the link referring to the citeproc formatting is broken; I'll open a second issue for this.